### PR TITLE
Support aggregated queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.so
 *.dylib
 
+#vscode debug binary
+__debug_bin
+
 # Test binary, build with `go test -c`
 *.test
 
@@ -15,10 +18,11 @@
 /warcserver
 
 # Gowarc cache
-/warcdb
+/warcdb*
 
 # User specific config
-/config.yaml
+/config*.yaml
 
 .idea
 /proto/tools/
+/.vscode

--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ You can configure certain aspect of gowarcserver with a config file. Here are al
 | warcPort      |  int           | The port that the serve command will use if not overridden as argument to serve      | 9999      |
 | logLevel      |  string        | Change the application log level manually                                            | "info"    |
 | compression   |  string        | Change the db table compression. Legal values are: 'none', 'snappy', 'zstd'          | "none"    |
+| idDb          |  bool          | true *Disables* id db, false *Enables* id db                                         | false     |
+| fileDb        |  bool          | true *Disables* file db, false *Enables* file db                                     | false     | 
+| cdxDb         |  bool          | true *Disables* cdx db, false *Enables* cdx db                                       | false     |
+| childUrls     |  []string      | Register urls pointing to gowarcserver processes which are 'children'                | [""]      |
+| childQueryTimeout | int        | How long in miliseconds a request to a child can take before resulting in timeout    | 300       |

--- a/cmd/warcserver/cmd/serve/buildurl_test.go
+++ b/cmd/warcserver/cmd/serve/buildurl_test.go
@@ -1,0 +1,68 @@
+package serve_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/nlnwa/gowarcserver/cmd/warcserver/cmd/serve"
+)
+
+func TestBuildUrlSlice(t *testing.T) {
+	tests := []struct {
+		name           string
+		urlStrs        []string
+		expectedUrls   []url.URL
+		expectedErrors int
+	}{
+		{
+			"parsing empty slice",
+			[]string{},
+			[]url.URL{},
+			0,
+		},
+		{
+			"parsing multiple urls",
+			[]string{
+				"http://192.148.38.150:8888",
+				"http://192.148.38.150:7777",
+			},
+			[]url.URL{
+				{
+					Scheme: "http",
+					Host:   "192.148.38.150:8888",
+				},
+				{
+					Scheme: "http",
+					Host:   "192.148.38.150:7777",
+				},
+			},
+			0,
+		},
+		{
+			"parsing invalid url",
+			[]string{
+				"1.22.333:4444",
+			},
+			[]url.URL{},
+			1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.urlStrs)-tt.expectedErrors != len(tt.expectedUrls) {
+				t.Errorf("test url slice and string slice does not have the same length")
+				return
+			}
+
+			urls := serve.BuildUrlSlice(tt.urlStrs)
+			println(urls)
+			for i, url := range urls {
+				expected := tt.expectedUrls[i]
+				if url != expected {
+					t.Errorf("Expected %v got %v", expected, url)
+				}
+			}
+		})
+	}
+}

--- a/cmd/warcserver/cmd/serve/mask_test.go
+++ b/cmd/warcserver/cmd/serve/mask_test.go
@@ -1,10 +1,11 @@
-package serve
+package serve_test
 
 import (
 	"fmt"
 	"strconv"
 	"testing"
 
+	"github.com/nlnwa/gowarcserver/cmd/warcserver/cmd/serve"
 	"github.com/nlnwa/gowarcserver/pkg/index"
 )
 
@@ -69,7 +70,7 @@ func TestConfigToDBMask(t *testing.T) {
 		bits := strconv.FormatInt(int64(tt.expected), 2)
 		testName := fmt.Sprintf("%t, %t, %t results in 0b%s", tt.noIdDB, tt.noFileDB, tt.noCdxDb, bits)
 		t.Run(testName, func(t *testing.T) {
-			mask := ConfigToDBMask(tt.noIdDB, tt.noFileDB, tt.noCdxDb)
+			mask := serve.ConfigToDBMask(tt.noIdDB, tt.noFileDB, tt.noCdxDb)
 			if mask != tt.expected {
 				bitMask := strconv.FormatInt(int64(mask), 2)
 				t.Errorf("Expected 0b%s got 0b%s", bits, bitMask)

--- a/cmd/warcserver/cmd/serve/serve.go
+++ b/cmd/warcserver/cmd/serve/serve.go
@@ -16,6 +16,9 @@
 package serve
 
 import (
+	"net/url"
+	"time"
+
 	"github.com/nlnwa/gowarcserver/pkg/index"
 	"github.com/nlnwa/gowarcserver/pkg/server"
 	log "github.com/sirupsen/logrus"
@@ -41,12 +44,14 @@ func NewCommand() *cobra.Command {
 
 	// Stub to hold flags
 	c := &struct {
-		warcPort   int
-		watchDepth int
-		autoIndex  bool
-		noIdDB     bool
-		noFileDB   bool
-		noCdxDB    bool
+		warcPort          int
+		watchDepth        int
+		autoIndex         bool
+		noIdDB            bool
+		noFileDB          bool
+		noCdxDB           bool
+		childUrls         []string
+		childQueryTimeout time.Duration
 	}{}
 	cmd.Flags().IntVarP(&c.warcPort, "warcPort", "p", 9999, "Port that should be used to serve, will use config value otherwise")
 	cmd.Flags().IntVarP(&c.watchDepth, "watchDepth", "w", 4, "Maximum depth when indexing warc")
@@ -54,6 +59,8 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().BoolVarP(&c.noIdDB, "idDb", "i", false, "Turn off id db")
 	cmd.Flags().BoolVarP(&c.noFileDB, "fileDb", "f", false, "Turn off file db")
 	cmd.Flags().BoolVarP(&c.noCdxDB, "cdxDb", "x", false, "Turn off cdx db")
+	cmd.Flags().StringSliceVarP(&c.childUrls, "childUrls", "u", []string{""}, "specify urls to other gowarcserver instances, queries are propagated to these urls")
+	cmd.Flags().DurationVarP(&c.childQueryTimeout, "childQueryTimeout", "t", time.Millisecond*300, "Time before query to child node times out")
 	if err := viper.BindPFlags(cmd.Flags()); err != nil {
 		log.Fatalf("Failed to bind serve flags, err: %v", err)
 	}
@@ -83,9 +90,21 @@ func runE(warcDirs []string) error {
 		defer autoindexer.Shutdown()
 	}
 
+	// TODO: function that can be tested
+	urlStrs := viper.GetStringSlice("childUrls")
+	var childUrls []url.URL
+	for _, urlstr := range urlStrs {
+		if u, err := url.Parse(urlstr); err != nil {
+			log.Warnf("Parsing config child url %s failed with error %v", urlstr, err)
+		} else {
+			childUrls = append(childUrls, *u)
+		}
+	}
+
+	childQueryTimeout := viper.GetDuration("childQueryTimeout")
 	port := viper.GetInt("warcPort")
 	log.Infof("Starting web server at http://localhost:%v", port)
-	err = server.Serve(db, port)
+	err = server.Serve(db, port, childUrls, childQueryTimeout)
 	if err != nil {
 		log.Warnf("%v", err)
 	}

--- a/cmd/warcserver/cmd/serve/serve.go
+++ b/cmd/warcserver/cmd/serve/serve.go
@@ -90,17 +90,7 @@ func runE(warcDirs []string) error {
 		defer autoindexer.Shutdown()
 	}
 
-	// TODO: function that can be tested
-	urlStrs := viper.GetStringSlice("childUrls")
-	var childUrls []url.URL
-	for _, urlstr := range urlStrs {
-		if u, err := url.Parse(urlstr); err != nil {
-			log.Warnf("Parsing config child url %s failed with error %v", urlstr, err)
-		} else {
-			childUrls = append(childUrls, *u)
-		}
-	}
-
+	childUrls := BuildUrlSlice(viper.GetStringSlice("childUrls"))
 	childQueryTimeout := viper.GetDuration("childQueryTimeout")
 	port := viper.GetInt("warcPort")
 	log.Infof("Starting web server at http://localhost:%v", port)
@@ -109,6 +99,18 @@ func runE(warcDirs []string) error {
 		log.Warnf("%v", err)
 	}
 	return nil
+}
+
+func BuildUrlSlice(urlStrs []string) []url.URL {
+	var childUrls []url.URL
+	for _, urlstr := range urlStrs {
+		if u, err := url.Parse(urlstr); err != nil {
+			log.Warnf("Parsing config child url %s failed with error %v", urlstr, err)
+		} else {
+			childUrls = append(childUrls, *u)
+		}
+	}
+	return childUrls
 }
 
 func ConfigToDBMask(noIdDB bool, noFileDB bool, noCdxDB bool) int32 {

--- a/exampleconfig.yaml
+++ b/exampleconfig.yaml
@@ -1,1 +1,3 @@
-logLevel: warn
+logLevel: info
+warcDir:
+  - ./testdata

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -18,6 +18,7 @@ package loader
 
 import (
 	"context"
+
 	"github.com/nlnwa/gowarc/warcrecord"
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/server/contenthandler.go
+++ b/pkg/server/contenthandler.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/nlnwa/gowarc/warcrecord"
@@ -35,7 +36,7 @@ type contentHandler struct {
 }
 
 func (h *contentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	localhttp.FirstQuery(h, w, r)
+	localhttp.FirstQuery(h, w, r, time.Second*3)
 }
 
 func (h *contentHandler) ServeLocalHTTP(wg *sync.WaitGroup, r *http.Request) (*localhttp.Writer, error) {

--- a/pkg/server/contenthandler.go
+++ b/pkg/server/contenthandler.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -39,7 +38,7 @@ func (h *contentHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	localhttp.FirstQuery(h, w, r, time.Second*3)
 }
 
-func (h *contentHandler) ServeLocalHTTP(wg *sync.WaitGroup, r *http.Request) (*localhttp.Writer, error) {
+func (h *contentHandler) ServeLocalHTTP(r *http.Request) (*localhttp.Writer, error) {
 	warcid := mux.Vars(r)["id"]
 	if len(warcid) > 0 && warcid[0] != '<' {
 		warcid = "<" + warcid + ">"

--- a/pkg/server/filehandler.go
+++ b/pkg/server/filehandler.go
@@ -19,24 +19,41 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/nlnwa/gowarcserver/pkg/index"
 	"github.com/nlnwa/gowarcserver/pkg/loader"
-	log "github.com/sirupsen/logrus"
+	"github.com/nlnwa/gowarcserver/pkg/server/localhttp"
 )
 
 type fileHandler struct {
-	loader *loader.Loader
-	db     *index.DB
+	loader   *loader.Loader
+	db       *index.DB
+	children *localhttp.Children
 }
 
 func (h *fileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	localhttp.AggregatedQuery(h, w, r)
+}
+
+func (h *fileHandler) ServeLocalHTTP(wg *sync.WaitGroup, r *http.Request) (*localhttp.Writer, error) {
 	files, err := h.db.ListFileNames()
 	if err != nil {
-		log.Fatalf("error reading files: %v", err)
+		return nil, fmt.Errorf("error reading files: %v", err)
 	}
-	w.Header().Set("Content-Type", "text/plain")
+
+	localWriter := localhttp.NewWriter()
+	localWriter.Header().Set("Content-Type", "text/plain")
 	for _, f := range files {
-		fmt.Fprintf(w, "%v\n", f)
+		fmt.Fprintf(localWriter, "%v\n", f)
 	}
+	return localWriter, nil
+}
+
+func (h *fileHandler) PredicateFn(r *http.Response) bool {
+	return r.StatusCode >= 200 && r.StatusCode < 300
+}
+
+func (h *fileHandler) Children() *localhttp.Children {
+	return h.children
 }

--- a/pkg/server/filehandler.go
+++ b/pkg/server/filehandler.go
@@ -19,7 +19,6 @@ package server
 import (
 	"fmt"
 	"net/http"
-	"sync"
 
 	"github.com/nlnwa/gowarcserver/pkg/index"
 	"github.com/nlnwa/gowarcserver/pkg/loader"
@@ -36,7 +35,7 @@ func (h *fileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	localhttp.AggregatedQuery(h, w, r)
 }
 
-func (h *fileHandler) ServeLocalHTTP(wg *sync.WaitGroup, r *http.Request) (*localhttp.Writer, error) {
+func (h *fileHandler) ServeLocalHTTP(r *http.Request) (*localhttp.Writer, error) {
 	files, err := h.db.ListFileNames()
 	if err != nil {
 		return nil, fmt.Errorf("error reading files: %v", err)

--- a/pkg/server/localhttp/childhandler.go
+++ b/pkg/server/localhttp/childhandler.go
@@ -16,13 +16,9 @@ type Children struct {
 	Timeout time.Duration
 }
 
-type Aggregator interface {
-	Aggregate(handler *Children, resut chan<- Writer)
-}
-
 type ResponsePredicateFn func(*http.Response) bool
 
-type QueryData struct {
+type ChildQueryData struct {
 	// Used to dictate if a response should be included in response channel
 	// true means it should be included, false will cause an early return for a given child
 	PredicateFn ResponsePredicateFn
@@ -32,7 +28,7 @@ type QueryData struct {
 	Response    chan<- Writer
 }
 
-func ChildQuery(queryData QueryData) {
+func ChildQuery(queryData ChildQueryData) {
 	var wgDoneFn func()
 	if queryData.Wg != nil {
 		wgDoneFn = func() {

--- a/pkg/server/localhttp/childhandler.go
+++ b/pkg/server/localhttp/childhandler.go
@@ -1,0 +1,80 @@
+package localhttp
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type Children struct {
+	Urls    []url.URL
+	Timeout time.Duration
+}
+
+type Aggregator interface {
+	Aggregate(handler *Children, resut chan<- Writer)
+}
+
+type ResponsePredicateFn func(*http.Response) bool
+
+type QueryData struct {
+	// Used to dictate if a response should be included in response channel
+	// true means it should be included, false will cause an early return for a given child
+	PredicateFn ResponsePredicateFn
+	Wg          *sync.WaitGroup
+	NodeUrl     *url.URL
+	Children    *Children
+	Response    chan<- Writer
+}
+
+func ChildQuery(queryData QueryData) {
+	var wgDoneFn func()
+	if queryData.Wg != nil {
+		wgDoneFn = func() {
+			queryData.Wg.Done()
+		}
+	} else {
+		wgDoneFn = func() {}
+	}
+
+	for _, childUrl := range queryData.Children.Urls {
+		u := childUrl
+		go func(u *url.URL) {
+			defer wgDoneFn()
+
+			client := http.Client{
+				Timeout: queryData.Children.Timeout,
+			}
+			urlStr := BuildChildURLString(u, queryData.NodeUrl)
+			resp, err := client.Get(urlStr)
+			if err != nil {
+				log.Warnf("Query to %s resultet in error: %v", u, err)
+				return
+			}
+			defer resp.Body.Close()
+
+			if !queryData.PredicateFn(resp) {
+				return
+			}
+
+			bodyBytes, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				log.Printf("Failed to read response from child url %s: %v", u, err)
+				return
+			}
+			buffer := bytes.NewBuffer(bodyBytes)
+
+			response := Writer{
+				body:   buffer,
+				header: &resp.Header,
+				status: resp.StatusCode,
+			}
+			queryData.Response <- response
+		}(&u)
+	}
+}

--- a/pkg/server/localhttp/localhandler.go
+++ b/pkg/server/localhttp/localhandler.go
@@ -32,6 +32,7 @@ func FirstQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request, timeAft
 				}
 			}
 			w.Write(localWriter.Bytes())
+			w.WriteHeader(localWriter.status)
 		case <-time.After(timeAfter):
 			// TODO: LocalHandler should have a 'noResponseFn' that is called here
 			w.Header().Set("Content-Type", "text/plain")
@@ -46,6 +47,7 @@ func FirstQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request, timeAft
 // Query self and all children, all responses that passes the PredicateFn test is
 // written to the client through the response writer
 func AggregatedQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request) {
+	// TODO: write most common header in event of response
 	chanFn := func(responses <-chan Writer, w http.ResponseWriter) {
 		var i int
 		for localWriter := range responses {

--- a/pkg/server/localhttp/localhandler.go
+++ b/pkg/server/localhttp/localhandler.go
@@ -9,7 +9,7 @@ import (
 type LocalHandler interface {
 	// Function used to query self. It will return a Writer in the event of
 	// no error and this will be sent to a repsonse channel if present
-	ServeLocalHTTP(wg *sync.WaitGroup, r *http.Request) (*Writer, error)
+	ServeLocalHTTP(r *http.Request) (*Writer, error)
 	// PredicateFn allows a handler to filter out responses from child processes
 	// if they do not meet a certain criteria. True means that the response is
 	// acceptable to be used, a false will mean that the response should be discarded
@@ -86,7 +86,7 @@ func CustomQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request, chanFn
 
 	go func() {
 		defer waitGroup.Done()
-		localWriter, err := lh.ServeLocalHTTP(&waitGroup, r)
+		localWriter, err := lh.ServeLocalHTTP(r)
 		if err != nil {
 			return
 		}

--- a/pkg/server/localhttp/localhandler.go
+++ b/pkg/server/localhttp/localhandler.go
@@ -3,40 +3,51 @@ package localhttp
 import (
 	"net/http"
 	"sync"
+	"time"
 )
 
-// TODO: document this file (properly comment stuff)
-// TODO: timeout a go rourine that has no results https://gobyexample.com/timeouts
-// 		 this should also call a timoutFn
-// 		 this should happen if the go channel times out in localhandler
-// 		 w.Header().Set("Content-Type", "text/plain")
-// 		 w.WriteHeader(404)
-// 		 w.Write([]byte("Document not found\n"))
-
 type LocalHandler interface {
+	// Function used to query self. It will return a Writer in the event of
+	// no error and this will be sent to a repsonse channel if present
 	ServeLocalHTTP(wg *sync.WaitGroup, r *http.Request) (*Writer, error)
+	// PredicateFn allows a handler to filter out responses from child processes
+	// if they do not meet a certain criteria. True means that the response is
+	// acceptable to be used, a false will mean that the response should be discarded
 	PredicateFn(r *http.Response) bool
+	// retrive the children struct from the interface instance
 	Children() *Children
 }
 
 type ChannelFn func(responses <-chan Writer, w http.ResponseWriter)
 
-func FirstQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request) {
+// Query self and all children, the first response that passes the PredicateFn test is
+// written to the client through the response writer
+func FirstQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request, timeAfter time.Duration) {
 	chanFn := func(responses <-chan Writer, w http.ResponseWriter) {
-		localWriter := <-responses
-		for key, values := range localWriter.Header() {
-			for _, value := range values {
-				w.Header().Add(key, value)
+		select {
+		case localWriter := <-responses:
+			for key, values := range localWriter.Header() {
+				for _, value := range values {
+					w.Header().Add(key, value)
+				}
 			}
+			w.Write(localWriter.Bytes())
+		case <-time.After(timeAfter):
+			// TODO: LocalHandler should have a 'noResponseFn' that is called here
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(404)
+			w.Write([]byte("Document not found\n"))
 		}
-		w.Write(localWriter.Bytes())
 	}
 
 	CustomQuery(lh, w, r, chanFn)
 }
 
+// Query self and all children, all responses that passes the PredicateFn test is
+// written to the client through the response writer
 func AggregatedQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request) {
 	chanFn := func(responses <-chan Writer, w http.ResponseWriter) {
+		var i int
 		for localWriter := range responses {
 			for key, values := range localWriter.Header() {
 				for _, value := range values {
@@ -44,12 +55,21 @@ func AggregatedQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			w.Write(localWriter.Bytes())
+			i += 1
+		}
+		if i <= 0 {
+			// TODO: LocalHandler should have a 'noResponseFn' that is called here
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(404)
+			w.Write([]byte("Document not found\n"))
 		}
 	}
 
 	CustomQuery(lh, w, r, chanFn)
 }
 
+// Query self and all children, responses are sent into the custom chanFn using the responses channel parameter
+// allowing the caller to specify how the channel should interperet and use the response(s)
 func CustomQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request, chanFn ChannelFn) {
 	workCount := len(lh.Children().Urls) + 1
 	responses := make(chan Writer, workCount)
@@ -66,26 +86,12 @@ func CustomQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request, chanFn
 		defer waitGroup.Done()
 		localWriter, err := lh.ServeLocalHTTP(&waitGroup, r)
 		if err != nil {
-			// TODO: error handling should only occur when response is empty
-			// and we got an error of (some) severity in one or more of the nodes
-			// w.Header().Set("Content-Type", "text/plain")
-			// fmt.Fprint(w, err)
-
-			// // if the error is from a malformed url being parsed, then the url is invalid
-			// if _, ok := err.(*whatwg.UrlError); ok {
-			// 	// 422: the url is unprocessanble.
-			// 	w.WriteHeader(http.StatusUnprocessableEntity)
-			// } else {
-			// 	// 500: unexpected error recieved
-			// 	w.WriteHeader(http.StatusInternalServerError)
-			// }
-
 			return
 		}
 		responses <- *localWriter
 	}()
 
-	queryData := QueryData{
+	queryData := ChildQueryData{
 		PredicateFn: lh.PredicateFn,
 		Wg:          &waitGroup,
 		NodeUrl:     r.URL,

--- a/pkg/server/localhttp/localhandler.go
+++ b/pkg/server/localhttp/localhandler.go
@@ -1,0 +1,98 @@
+package localhttp
+
+import (
+	"net/http"
+	"sync"
+)
+
+// TODO: document this file (properly comment stuff)
+// TODO: timeout a go rourine that has no results https://gobyexample.com/timeouts
+// 		 this should also call a timoutFn
+// 		 this should happen if the go channel times out in localhandler
+// 		 w.Header().Set("Content-Type", "text/plain")
+// 		 w.WriteHeader(404)
+// 		 w.Write([]byte("Document not found\n"))
+
+type LocalHandler interface {
+	ServeLocalHTTP(wg *sync.WaitGroup, r *http.Request) (*Writer, error)
+	PredicateFn(r *http.Response) bool
+	Children() *Children
+}
+
+type ChannelFn func(responses <-chan Writer, w http.ResponseWriter)
+
+func FirstQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request) {
+	chanFn := func(responses <-chan Writer, w http.ResponseWriter) {
+		localWriter := <-responses
+		for key, values := range localWriter.Header() {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
+		w.Write(localWriter.Bytes())
+	}
+
+	CustomQuery(lh, w, r, chanFn)
+}
+
+func AggregatedQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request) {
+	chanFn := func(responses <-chan Writer, w http.ResponseWriter) {
+		for localWriter := range responses {
+			for key, values := range localWriter.Header() {
+				for _, value := range values {
+					w.Header().Add(key, value)
+				}
+			}
+			w.Write(localWriter.Bytes())
+		}
+	}
+
+	CustomQuery(lh, w, r, chanFn)
+}
+
+func CustomQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request, chanFn ChannelFn) {
+	workCount := len(lh.Children().Urls) + 1
+	responses := make(chan Writer, workCount)
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(workCount)
+
+	go func() {
+		waitGroup.Wait()
+		close(responses)
+	}()
+
+	go func() {
+		defer waitGroup.Done()
+		localWriter, err := lh.ServeLocalHTTP(&waitGroup, r)
+		if err != nil {
+			// TODO: error handling should only occur when response is empty
+			// and we got an error of (some) severity in one or more of the nodes
+			// w.Header().Set("Content-Type", "text/plain")
+			// fmt.Fprint(w, err)
+
+			// // if the error is from a malformed url being parsed, then the url is invalid
+			// if _, ok := err.(*whatwg.UrlError); ok {
+			// 	// 422: the url is unprocessanble.
+			// 	w.WriteHeader(http.StatusUnprocessableEntity)
+			// } else {
+			// 	// 500: unexpected error recieved
+			// 	w.WriteHeader(http.StatusInternalServerError)
+			// }
+
+			return
+		}
+		responses <- *localWriter
+	}()
+
+	queryData := QueryData{
+		PredicateFn: lh.PredicateFn,
+		Wg:          &waitGroup,
+		NodeUrl:     r.URL,
+		Children:    lh.Children(),
+		Response:    responses,
+	}
+	ChildQuery(queryData)
+
+	chanFn(responses, w)
+}

--- a/pkg/server/localhttp/localhandler.go
+++ b/pkg/server/localhttp/localhandler.go
@@ -31,13 +31,21 @@ func FirstQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request, timeAft
 					w.Header().Add(key, value)
 				}
 			}
-			w.Write(localWriter.Bytes())
+			_, err := w.Write(localWriter.Bytes())
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 			w.WriteHeader(localWriter.status)
 		case <-time.After(timeAfter):
 			// TODO: LocalHandler should have a 'noResponseFn' that is called here
 			w.Header().Set("Content-Type", "text/plain")
-			w.WriteHeader(404)
-			w.Write([]byte("Document not found\n"))
+			_, err := w.Write([]byte("Document not found\n"))
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
 		}
 	}
 
@@ -56,14 +64,22 @@ func AggregatedQuery(lh LocalHandler, w http.ResponseWriter, r *http.Request) {
 					w.Header().Add(key, value)
 				}
 			}
-			w.Write(localWriter.Bytes())
+			_, err := w.Write(localWriter.Bytes())
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 			i += 1
 		}
 		if i <= 0 {
 			// TODO: LocalHandler should have a 'noResponseFn' that is called here
 			w.Header().Set("Content-Type", "text/plain")
+			_, err := w.Write([]byte("Document not found\n"))
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 			w.WriteHeader(404)
-			w.Write([]byte("Document not found\n"))
 		}
 	}
 

--- a/pkg/server/localhttp/url.go
+++ b/pkg/server/localhttp/url.go
@@ -1,0 +1,14 @@
+package localhttp
+
+import "net/url"
+
+func BuildChildURLString(childBase *url.URL, nodeUrl *url.URL) string {
+	rtr := url.URL{}
+	rtr.Scheme = childBase.Scheme
+	rtr.Host = childBase.Host
+	rtr.Path = nodeUrl.Path
+	rtr.RawQuery = nodeUrl.RawQuery
+	rtr.Fragment = nodeUrl.Fragment
+
+	return rtr.String()
+}

--- a/pkg/server/localhttp/url_test.go
+++ b/pkg/server/localhttp/url_test.go
@@ -1,0 +1,79 @@
+package localhttp_test
+
+import (
+	"log"
+	"net/url"
+	"testing"
+
+	"github.com/nlnwa/gowarcserver/pkg/server/localhttp"
+)
+
+func TestConfigToDBMask(t *testing.T) {
+	tests := []struct {
+		name        string
+		nodeUrlStr  string
+		childUrlStr string
+		expectedUrl string
+	}{
+		{
+			"simple nop",
+			"http://190.165.33.152:8080",
+			"http://190.165.33.152:9999",
+			"http://190.165.33.152:9999",
+		},
+		{
+			"dont include child non-host",
+			"http://190.165.33.152:8080",
+			"http://190.165.33.152:9999/yes?foo=bar#ez",
+			"http://190.165.33.152:9999",
+		},
+		{
+			"path",
+			"http://190.165.33.152:8080/foo",
+			"http://190.165.33.152:9999",
+			"http://190.165.33.152:9999/foo",
+		},
+		{
+			"query",
+			"http://190.165.33.152:8080?foo=bar",
+			"http://190.165.33.152:9999",
+			"http://190.165.33.152:9999?foo=bar",
+		},
+		{
+			"fragment",
+			"http://190.165.33.152:8080#foo",
+			"http://190.165.33.152:9999",
+			"http://190.165.33.152:9999#foo",
+		},
+		{
+			"path&query",
+			"http://190.165.33.152:8080/path?foo=bar",
+			"http://190.165.33.152:9999",
+			"http://190.165.33.152:9999/path?foo=bar",
+		},
+		{
+			"path&query&fragment",
+			"http://190.165.33.152:8080/path?foo=bar#f",
+			"http://190.165.33.152:9999",
+			"http://190.165.33.152:9999/path?foo=bar#f",
+		},
+	}
+
+	for _, tt := range tests {
+		var err error
+		childUrl, err := url.Parse(tt.childUrlStr)
+		if err != nil {
+			log.Fatal("illegal child url test string, msg: ", err)
+		}
+		nodeUrl, err := url.Parse(tt.nodeUrlStr)
+		if err != nil {
+			log.Fatal("illegal node url test string, msg: ", err)
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			result := localhttp.BuildChildURLString(childUrl, nodeUrl)
+			if result != tt.expectedUrl {
+				t.Errorf("Expected %s got %s", tt.expectedUrl, result)
+			}
+		})
+	}
+}

--- a/pkg/server/localhttp/writer.go
+++ b/pkg/server/localhttp/writer.go
@@ -1,0 +1,51 @@
+package localhttp
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+)
+
+// Used by the gowarcserver handlers to write a local respons from a request.
+// This makes it easier to uniformly deal with aggregated request results and local results
+// It implements the ResponseWriter interface in order to achieve this
+type Writer struct {
+	body   *bytes.Buffer
+	header *http.Header
+	status int
+}
+
+func NewWriter() *Writer {
+	body := bytes.NewBuffer([]byte{})
+	header := http.Header(make(map[string][]string))
+	return &Writer{
+		body:   body,
+		header: &header,
+		status: -1,
+	}
+}
+
+func (l *Writer) Bytes() []byte {
+	if l.body == nil {
+		return []byte{}
+	}
+	return l.body.Bytes()
+}
+
+func (l *Writer) Header() http.Header {
+	if l.header == nil {
+		return nil
+	}
+	return *l.header
+}
+
+func (l *Writer) Write(bytes []byte) (n int, err error) {
+	if l.body == nil {
+		return 0, errors.New("writer missing buffer")
+	}
+	return l.body.Write(bytes)
+}
+
+func (l *Writer) WriteHeader(statusCode int) {
+	l.status = statusCode
+}

--- a/pkg/server/searchhandler.go
+++ b/pkg/server/searchhandler.go
@@ -19,6 +19,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/dgraph-io/badger/v3"
 	"github.com/golang/protobuf/jsonpb"
@@ -26,27 +27,32 @@ import (
 	cdx "github.com/nlnwa/gowarc/proto"
 	"github.com/nlnwa/gowarcserver/pkg/index"
 	"github.com/nlnwa/gowarcserver/pkg/loader"
+	"github.com/nlnwa/gowarcserver/pkg/server/localhttp"
 	"github.com/nlnwa/gowarcserver/pkg/surt"
-	whatwg "github.com/nlnwa/whatwg-url/errors"
 	log "github.com/sirupsen/logrus"
 )
 
 type searchHandler struct {
-	loader *loader.Loader
-	db     *index.DB
+	loader   *loader.Loader
+	db       *index.DB
+	children *localhttp.Children
 }
 
 var jsonMarshaler = &jsonpb.Marshaler{}
 
 func (h *searchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	localhttp.AggregatedQuery(h, w, r)
+}
+
+func (h *searchHandler) ServeLocalHTTP(wg *sync.WaitGroup, r *http.Request) (*localhttp.Writer, error) {
 	uri := r.URL.Query().Get("url")
 	key, err := surt.SsurtString(uri, true)
 	if err != nil {
-		h.handleError(err, w)
-		return
+		return nil, err
 	}
 
 	log.Infof("request url: %v, key: %v", uri, key)
+	localWriter := localhttp.NewWriter()
 
 	perItemFn := func(item *badger.Item) bool {
 		result := &cdx.Cdx{}
@@ -57,7 +63,7 @@ func (h *searchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(w, "%s %s %s %s\n\n", result.Ssu, result.Sts, result.Srt, cdxj)
+			fmt.Fprintf(localWriter, "%s %s %s %s\n\n", result.Ssu, result.Sts, result.Srt, cdxj)
 
 			return nil
 		})
@@ -70,22 +76,14 @@ func (h *searchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return nil
 	}
 	h.db.Search(key, false, perItemFn, afterIterFn)
+
+	return localWriter, nil
 }
 
-func (h *searchHandler) handleError(err error, w http.ResponseWriter) {
-	if err == nil {
-		return
-	}
+func (h *searchHandler) PredicateFn(r *http.Response) bool {
+	return r.StatusCode >= 200 && r.StatusCode < 300
+}
 
-	w.Header().Set("Content-Type", "text/plain")
-	fmt.Fprint(w, err)
-
-	// if the error is from a malformed url being parsed, then the url is invalid
-	if _, ok := err.(*whatwg.UrlError); ok {
-		// 422: the url is unprocessanble.
-		w.WriteHeader(http.StatusUnprocessableEntity)
-	} else {
-		// 500: unexpected error receved
-		w.WriteHeader(http.StatusInternalServerError)
-	}
+func (h *searchHandler) Children() *localhttp.Children {
+	return h.children
 }

--- a/pkg/server/searchhandler.go
+++ b/pkg/server/searchhandler.go
@@ -19,7 +19,6 @@ package server
 import (
 	"fmt"
 	"net/http"
-	"sync"
 
 	"github.com/dgraph-io/badger/v3"
 	"github.com/golang/protobuf/jsonpb"
@@ -44,7 +43,7 @@ func (h *searchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	localhttp.AggregatedQuery(h, w, r)
 }
 
-func (h *searchHandler) ServeLocalHTTP(wg *sync.WaitGroup, r *http.Request) (*localhttp.Writer, error) {
+func (h *searchHandler) ServeLocalHTTP(r *http.Request) (*localhttp.Writer, error) {
 	uri := r.URL.Query().Get("url")
 	key, err := surt.SsurtString(uri, true)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -30,10 +31,11 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/nlnwa/gowarcserver/pkg/index"
 	"github.com/nlnwa/gowarcserver/pkg/loader"
+	"github.com/nlnwa/gowarcserver/pkg/server/localhttp"
 	"github.com/nlnwa/gowarcserver/pkg/server/warcserver"
 )
 
-func Serve(db *index.DB, port int) error {
+func Serve(db *index.DB, port int, childUrls []url.URL, childTimeout time.Duration) error {
 	l := &loader.Loader{
 		Resolver: &storageRefResolver{db: db},
 		Loader: &loader.FileStorageLoader{FilePathResolver: func(fileName string) (filePath string, err error) {
@@ -43,12 +45,17 @@ func Serve(db *index.DB, port int) error {
 		NoUnpack: false,
 	}
 
+	children := &localhttp.Children{
+		Urls:    childUrls,
+		Timeout: childTimeout,
+	}
+
 	r := mux.NewRouter()
-	r.Handle("/id/{id}", &contentHandler{l})
-	r.Handle("/files/", &fileHandler{l, db})
-	r.Handle("/search", &searchHandler{l, db})
+	r.Handle("/id/{id}", &contentHandler{l, children})
+	r.Handle("/files/", &fileHandler{l, db, children})
+	r.Handle("/search", &searchHandler{l, db, children})
 	warcserverRoutes := r.PathPrefix("/warcserver").Subrouter()
-	warcserver.RegisterRoutes(warcserverRoutes, db, l)
+	warcserver.RegisterRoutes(warcserverRoutes, db, l, children)
 	http.Handle("/", r)
 
 	loggingMw := func(h http.Handler) http.Handler {

--- a/pkg/server/warcserver/indexhandler.go
+++ b/pkg/server/warcserver/indexhandler.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/dgraph-io/badger/v3"
 	cdx "github.com/nlnwa/gowarc/proto"
@@ -40,7 +39,7 @@ func (h *indexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	localhttp.AggregatedQuery(h, w, r)
 }
 
-func (h *indexHandler) ServeLocalHTTP(wg *sync.WaitGroup, r *http.Request) (*localhttp.Writer, error) {
+func (h *indexHandler) ServeLocalHTTP(r *http.Request) (*localhttp.Writer, error) {
 	var renderFunc RenderFunc = func(w *localhttp.Writer, record *cdx.Cdx, cdxApi *cdxServerApi) error {
 		cdxj, err := json.Marshal(cdxjTopywbJson(record))
 		if err != nil {

--- a/pkg/server/warcserver/resourcehandler.go
+++ b/pkg/server/warcserver/resourcehandler.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/dgraph-io/badger/v3"
 	cdx "github.com/nlnwa/gowarc/proto"
@@ -41,7 +42,7 @@ type resourceHandler struct {
 }
 
 func (h *resourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	localhttp.FirstQuery(h, w, r)
+	localhttp.FirstQuery(h, w, r, time.Second*3)
 }
 
 func (h *resourceHandler) ServeLocalHTTP(wg *sync.WaitGroup, r *http.Request) (*localhttp.Writer, error) {

--- a/pkg/server/warcserver/resourcehandler.go
+++ b/pkg/server/warcserver/resourcehandler.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/dgraph-io/badger/v3"
@@ -45,7 +44,7 @@ func (h *resourceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	localhttp.FirstQuery(h, w, r, time.Second*3)
 }
 
-func (h *resourceHandler) ServeLocalHTTP(wg *sync.WaitGroup, r *http.Request) (*localhttp.Writer, error) {
+func (h *resourceHandler) ServeLocalHTTP(r *http.Request) (*localhttp.Writer, error) {
 	localWriter := localhttp.NewWriter()
 	var renderFunc RenderFunc = func(w *localhttp.Writer, record *cdx.Cdx, cdxApi *cdxServerApi) error {
 		warcid := record.Rid

--- a/pkg/server/warcserver/routes.go
+++ b/pkg/server/warcserver/routes.go
@@ -20,10 +20,11 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/nlnwa/gowarcserver/pkg/index"
 	"github.com/nlnwa/gowarcserver/pkg/loader"
+	"github.com/nlnwa/gowarcserver/pkg/server/localhttp"
 )
 
-func RegisterRoutes(r *mux.Router, db *index.DB, loader *loader.Loader) {
+func RegisterRoutes(r *mux.Router, db *index.DB, loader *loader.Loader, children *localhttp.Children) {
 	r.Handle("/", &rootHandler{})
-	r.Handle("/{collection}/index", &indexHandler{loader: loader, db: db})
-	r.Handle("/{collection}/resource", &resourceHandler{loader: loader, db: db})
+	r.Handle("/{collection}/index", &indexHandler{loader: loader, db: db, children: children})
+	r.Handle("/{collection}/resource", &resourceHandler{loader: loader, db: db, children: children})
 }


### PR DESCRIPTION
this PR implements queries to child nodes as described in issue #4
To achieve this there is a new package 'localhttp' that create an abstraction for among other things
writing a response from either the local node or its children