### PR TITLE
Add linting to CI

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,49 +1,23 @@
 name: Docker
 
 on:
-  push:
-    # Publish `master` as Docker `latest` image.
-    branches:
-      - master
-
-    # Publish `v1.2.3` tags as releases.
-    tags:
-      - v*
-
-  # Run tests for any PRs.
-  pull_request:
+  # Only trigger, when the linting & testing workflow complete
+  workflow_run:
+    workflows: ["golangci-lint", "golangci-test"]
+    types:
+      - completed
 
 env:
   IMAGE_NAME: gowarcserver
 
 jobs:
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
-  test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Run tests
-        run: |
-          if [ -f docker-compose.test.yml ]; then
-            docker-compose --file docker-compose.test.yml build
-            docker-compose --file docker-compose.test.yml run sut
-          else
-            docker build . --file Dockerfile
-          fi
-
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   # and https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images
   push:
-    # Ensure test job passes before pushing image.
-    needs: test
-
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-
+    # only run the push job if linting and testing was successfull
+    if: ${{github.event.workflow_run.conclusion == 'success'}}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,42 @@
+name: golangci-lint
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+  # Run tests for any PRs.
+  pull_request:
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.29
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the action will use pre-installed Go.
+          # skip-go-installation: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -1,0 +1,31 @@
+name: golangci-test
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  IMAGE_NAME: gowarcserver
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests
+        run: |
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+            docker-compose --file docker-compose.test.yml run sut
+          else
+            docker build . --file Dockerfile
+          fi

--- a/cmd/warcserver/cmd/index/index.go
+++ b/cmd/warcserver/cmd/index/index.go
@@ -83,6 +83,5 @@ func runE(c *conf, writer index.CdxWriter) error {
 	}
 	defer writer.Close()
 
-	ReadFile(c, writer)
-	return nil
+	return ReadFile(c, writer)
 }

--- a/cmd/warcserver/cmd/index/io.go
+++ b/cmd/warcserver/cmd/index/io.go
@@ -53,7 +53,7 @@ func ReadFile(c *conf, writer index.CdxWriter) error {
 
 		err = writer.Write(wr, c.fileName, currentOffset)
 		if err != nil {
-			log.Warnf("Failed to writer to %s: %v", c.fileName, err)
+			log.Warnf("Failed to write to %s at offset %d: %v", c.fileName, currentOffset, err)
 		}
 	}
 	return nil

--- a/cmd/warcserver/cmd/index/io.go
+++ b/cmd/warcserver/cmd/index/io.go
@@ -8,7 +8,7 @@ import (
 	"github.com/nlnwa/gowarc/warcoptions"
 	"github.com/nlnwa/gowarc/warcreader"
 	"github.com/nlnwa/gowarcserver/pkg/index"
-	logrus "github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func ParseFormat(format string) (index.CdxWriter, error) {
@@ -38,7 +38,7 @@ func ReadFile(c *conf, writer index.CdxWriter) error {
 	// avoid defer copy value by using a anonymous function
 	// At the end, print count even if an error occurs
 	defer func() {
-		logrus.Printf("Count: %d", count)
+		log.Printf("Count: %d", count)
 	}()
 
 	for {
@@ -51,7 +51,10 @@ func ReadFile(c *conf, writer index.CdxWriter) error {
 		}
 		count++
 
-		writer.Write(wr, c.fileName, currentOffset)
+		err = writer.Write(wr, c.fileName, currentOffset)
+		if err != nil {
+			log.Warnf("Failed to writer to %s: %v", c.fileName, err)
+		}
 	}
 	return nil
 }

--- a/cmd/warcserver/cmd/index/io_test.go
+++ b/cmd/warcserver/cmd/index/io_test.go
@@ -126,14 +126,17 @@ Content-Length: 0`)
 				tt.writerFormat,
 			}
 			dbConfig := index.NewDbConfig(t.TempDir(), "none", index.ALL_MASK)
-			tt.writer.Init(dbConfig)
+			err := tt.writer.Init(dbConfig)
+			if err != nil {
+				t.Errorf("writer init failed in test: %v", err)
+				return
+			}
 			defer tt.writer.Close()
 
-			err := ReadFile(c, tt.writer)
+			err = ReadFile(c, tt.writer)
 			if err != nil {
 				t.Errorf("Unexpected failure: %v", err)
 			}
-
 		})
 	}
 }

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -1,0 +1,4 @@
+# Githooks
+This folder contains an optional [githook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to run test and linting before a commit.
+
+Simply copy the pre-commit file into your *project_root*/.git/hooks/ folder

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+printf "Running pre-commit hook\n"
+
+HOOK_PATH=$(realpath $0)
+# Remove "/.git/hooks/pre-commit" from abs path, source: https://stackoverflow.com/a/31728689
+PROJECT_ROOT=$(echo $HOOK_PATH | rev | cut -d'/' -f4- | rev)
+# Run test and lint in parallel, source: https://stackoverflow.com/a/41762802
+go test $PROJECT_ROOT/... & TEST_JOB=$!
+golangci-lint run $PROJECT_ROOT/... & LINT_JOB=$!
+wait $TEST_JOB $LINT_JOB

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/dgraph-io/badger/v3 v3.2011.1
 	github.com/fsnotify/fsnotify v1.4.9
-	github.com/golang/protobuf v1.5.1
+	github.com/golang/protobuf v1.5.1 // indirect
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/nlnwa/gowarc v0.0.0-20210118115420-3b141daed171
@@ -16,6 +16,6 @@ require (
 	google.golang.org/protobuf v1.26.0
 )
 
-// HACK: as there are issues with sum value of v1.12.0, make sure to update this when badger updates its dependencies 
-// See issue: https://github.com/google/flatbuffers/issues/6466 
+// HACK: as there are issues with sum value of v1.12.0, make sure to update this when badger updates its dependencies
+// See issue: https://github.com/google/flatbuffers/issues/6466
 replace github.com/google/flatbuffers v1.12.0 => github.com/google/flatbuffers v1.12.1

--- a/pkg/index/cdx.go
+++ b/pkg/index/cdx.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nlnwa/gowarc/pkg/timestamp"
 	cdx "github.com/nlnwa/gowarc/proto"
 	"github.com/nlnwa/gowarc/warcrecord"
+	log "github.com/sirupsen/logrus"
 )
 
 func NewCdxRecord(wr warcrecord.WarcRecord, fileName string, offset int64) *cdx.Cdx {
@@ -52,12 +53,8 @@ func NewCdxRecord(wr warcrecord.WarcRecord, fileName string, offset int64) *cdx.
 			cdx.Mct = resp.Header.Get("Content-Type")
 			cdx.Ple = resp.Header.Get("Content-Length")
 		}
-	case *warcrecord.RevisitBlock:
-		if resp, err := v.Response(); err == nil {
-			cdx.Hsc = strconv.Itoa(resp.StatusCode)
-			cdx.Mct = resp.Header.Get("Content-Type")
-			cdx.Ple = resp.Header.Get("Content-Length")
-		}
+	default:
+		log.Fatal("Unreachable") // This is fatal and should never happen
 	}
 
 	return cdx

--- a/pkg/index/indexwriter.go
+++ b/pkg/index/indexwriter.go
@@ -19,9 +19,9 @@ package index
 import (
 	"fmt"
 
-	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/proto"
 	"github.com/nlnwa/gowarc/warcrecord"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 type CdxWriter interface {
@@ -33,10 +33,8 @@ type CdxWriter interface {
 type CdxLegacy struct {
 }
 type CdxJ struct {
-	jsonMarshaler *jsonpb.Marshaler
 }
 type CdxPb struct {
-	jsonMarshaler *jsonpb.Marshaler
 }
 type CdxDb struct {
 	db *DB
@@ -71,7 +69,6 @@ func (c *CdxLegacy) Write(wr warcrecord.WarcRecord, fileName string, offset int6
 }
 
 func (c *CdxJ) Init(config *DbConfig) (err error) {
-	c.jsonMarshaler = &jsonpb.Marshaler{}
 	return nil
 }
 
@@ -81,10 +78,7 @@ func (c *CdxJ) Close() {
 func (c *CdxJ) Write(wr warcrecord.WarcRecord, fileName string, offset int64) error {
 	if wr.Type() == warcrecord.RESPONSE {
 		rec := NewCdxRecord(wr, fileName, offset)
-		cdxj, err := c.jsonMarshaler.MarshalToString(rec)
-		if err != nil {
-			return err
-		}
+		cdxj := protojson.Format(rec)
 		fmt.Printf("%s %s %s %s\n", rec.Ssu, rec.Sts, rec.Srt, cdxj)
 	}
 	return nil

--- a/pkg/loader/filestorageloader.go
+++ b/pkg/loader/filestorageloader.go
@@ -19,13 +19,14 @@ package loader
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
 	"github.com/nlnwa/gowarc/warcoptions"
 	"github.com/nlnwa/gowarc/warcreader"
 	"github.com/nlnwa/gowarc/warcrecord"
 	log "github.com/sirupsen/logrus"
-	"os"
-	"strconv"
-	"strings"
 )
 
 type FileStorageLoader struct {
@@ -46,11 +47,9 @@ func (f *FileStorageLoader) Load(ctx context.Context, storageRef string) (record
 	}
 
 	go func() {
-		select {
-		case <-ctx.Done():
-			log.Tracef("File: %v closed\n", filePath)
-			wf.Close()
-		}
+		<-ctx.Done()
+		log.Tracef("File: %v closed\n", filePath)
+		wf.Close()
 	}()
 
 	record, _, err = wf.Next()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/nlnwa/gowarcserver/pkg/index"
 	"github.com/nlnwa/gowarcserver/pkg/loader"
 	"github.com/nlnwa/gowarcserver/pkg/server/warcserver"
+	"github.com/sirupsen/logrus"
 )
 
 func Serve(db *index.DB, port int) error {
@@ -67,7 +68,10 @@ func Serve(db *index.DB, port int) error {
 		<-sigs
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		httpServer.Shutdown(ctx)
+		err := httpServer.Shutdown(ctx)
+		if err != nil {
+			logrus.Warnf("Failed to shut down server: %v", err)
+		}
 	}()
 
 	return httpServer.ListenAndServe()

--- a/pkg/server/warcserver/indexhandler.go
+++ b/pkg/server/warcserver/indexhandler.go
@@ -26,6 +26,7 @@ import (
 	cdx "github.com/nlnwa/gowarc/proto"
 	"github.com/nlnwa/gowarcserver/pkg/index"
 	"github.com/nlnwa/gowarcserver/pkg/loader"
+	log "github.com/sirupsen/logrus"
 )
 
 type indexHandler struct {
@@ -68,9 +69,15 @@ func (h *indexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if cdxApi.sort.closest != "" {
-		h.db.Search(cdxApi.key, false, cdxApi.sort.add, cdxApi.sort.write)
+		err := h.db.Search(cdxApi.key, false, cdxApi.sort.add, cdxApi.sort.write)
+		if err != nil {
+			log.Warnf("Failed to search db: %v", err)
+		}
 	} else {
-		h.db.Search(cdxApi.key, cdxApi.sort.reverse, defaultPerItemFunc, defaultAfterIterationFunc)
+		err := h.db.Search(cdxApi.key, cdxApi.sort.reverse, defaultPerItemFunc, defaultAfterIterationFunc)
+		if err != nil {
+			log.Warnf("Failed to search db: %v", err)
+		}
 	}
 
 	// If no hits with http, try https
@@ -78,9 +85,15 @@ func (h *indexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		cdxApi.key = strings.ReplaceAll(cdxApi.key, "http:", "https:")
 
 		if cdxApi.sort.closest != "" {
-			h.db.Search(cdxApi.key, false, cdxApi.sort.add, cdxApi.sort.write)
+			err := h.db.Search(cdxApi.key, false, cdxApi.sort.add, cdxApi.sort.write)
+			if err != nil {
+				log.Warnf("Failed to search db: %v", err)
+			}
 		} else {
-			h.db.Search(cdxApi.key, cdxApi.sort.reverse, defaultPerItemFunc, defaultAfterIterationFunc)
+			err := h.db.Search(cdxApi.key, cdxApi.sort.reverse, defaultPerItemFunc, defaultAfterIterationFunc)
+			if err != nil {
+				log.Warnf("Failed to search db: %v", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This commit adds linting to the CI. It also makes linting and testing of the code run in parallel
The build job will wait and only run if both the linting and testing succeeds.

Currently we use the default linters enabled by the golangci-lint tool:
* deadcode
* errcheck
* gosimple
* govet
* ineffassign
* staticcheck
* structcheck
* typecheck
* unused
* varcheck

The tool should run all of the previously mentioned in parallel too, so the overhead of this should be relatively minor