### PR TITLE
docker build only on master, include version

### DIFF
--- a/.github/workflows/dockerimage-latest.yml
+++ b/.github/workflows/dockerimage-latest.yml
@@ -1,11 +1,13 @@
 name: Docker
 
 on:
-  # Only trigger, when the linting & testing workflow complete
-  workflow_run:
-    workflows: ["golangci-lint", "golangci-test"]
-    types:
-      - completed
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+  # Publish `v1.2.3` tags as releases.
+  tags:
+    - v*
 
 env:
   IMAGE_NAME: gowarcserver
@@ -17,7 +19,6 @@ jobs:
   push:
     runs-on: ubuntu-latest
     # only run the push job if linting and testing was successfull
-    if: ${{github.event.workflow_run.conclusion == 'success'}}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,9 +5,6 @@ on:
     # Publish `master` as Docker `latest` image.
     branches:
       - master
-    # Publish `v1.2.3` tags as releases.
-    tags:
-      - v*
   # Run tests for any PRs.
   pull_request:
 

--- a/.github/workflows/golangci-test.yml
+++ b/.github/workflows/golangci-test.yml
@@ -5,9 +5,6 @@ on:
     # Publish `master` as Docker `latest` image.
     branches:
       - master
-    # Publish `v1.2.3` tags as releases.
-    tags:
-      - v*
   # Run tests for any PRs.
   pull_request:
 


### PR DESCRIPTION
temporary fix for CI to fix issue where a docker build is made if EITHER linting OR testing succeeds which was incorrect behavior. It also did not include a version for the build. This resolves these issues at the cost of safety on master branch