### PR TITLE
Daterange test and stricter API use

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,7 +28,7 @@ jobs:
 
           # golangci-lint command line arguments.
           # Enable additional linters (see: https://golangci-lint.run/usage/linters/)
-          args: -E "bodyclose" -E "dogsled" -E "durationcheck" -E "errorlint" -E "forcetypeassert" -E "noctx" -E "exhaustive" -E "exportloopref"
+          args: -E "bodyclose" -E "dogsled" -E "durationcheck" -E "errorlint" -E "forcetypeassert" -E "noctx" -E "exhaustive" -E "exportloopref" --timeout 3m0s
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/pkg/server/warcserver/daterange.go
+++ b/pkg/server/warcserver/daterange.go
@@ -18,6 +18,7 @@ package warcserver
 
 import (
 	"fmt"
+	"strconv"
 )
 
 type DateRange struct {
@@ -26,8 +27,20 @@ type DateRange struct {
 }
 
 // contains returns true if the timestamp ts contained by the bounds defined by the DateRange d.
-func (d DateRange) contains(ts string) bool {
-	return ts >= d.from && ts <= d.to
+func (d DateRange) contains(ts string) (bool, error) {
+	from, err := strconv.Atoi(d.from)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse DateRange.from: %w", err)
+	}
+	to, err := strconv.Atoi(d.to)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse DateRange.to: %w", err)
+	}
+	timestamp, err := strconv.Atoi(ts)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse timestamp: %w", err)
+	}
+	return timestamp >= from && timestamp <= to, nil
 }
 
 // From pads the timestamp f with 0's on the right until the string is 14 characters in length.

--- a/pkg/server/warcserver/daterange.go
+++ b/pkg/server/warcserver/daterange.go
@@ -102,12 +102,10 @@ func To(t string) (int64, error) {
 
 	switch tLen {
 	case 4:
-		to = to.AddDate(0, 12, -1) // 31 days in decemeber
-		to = to.Add(time.Hour*23 + time.Minute*59 + time.Second*59)
+		to = to.AddDate(0, 12, -1).Add(time.Hour*23 + time.Minute*59 + time.Second*59)
 	case 6:
 		// add one month - one day, i.e: user supplies january, we add 29 - 1
-		to = to.AddDate(0, 1, -1)
-		to = to.Add(time.Hour*23 + time.Minute*59 + time.Second*59)
+		to = to.AddDate(0, 1, -1).Add(time.Hour*23 + time.Minute*59 + time.Second*59)
 	case 8:
 		to = to.Add(time.Hour*23 + time.Minute*59 + time.Second*59)
 	case 10:

--- a/pkg/server/warcserver/daterange_test.go
+++ b/pkg/server/warcserver/daterange_test.go
@@ -1,0 +1,115 @@
+package warcserver
+
+import (
+	"testing"
+)
+
+type dateRangeTestData struct {
+	name      string
+	daterange DateRange
+	timestamp string
+	expect    bool
+}
+
+func TestInValidDateRangeContains(t *testing.T) {
+	tests := []dateRangeTestData{
+		{
+			"invalid 'to' value fails",
+			DateRange{
+				from: "123",
+				to:   "a",
+			},
+			"100",
+			false,
+		},
+		{
+			"invalid 'from' value fails",
+			DateRange{
+				from: "a",
+				to:   "123",
+			},
+			"100",
+			false,
+		},
+		{
+			"invalid 'timestamp' value fails",
+			DateRange{
+				from: "100",
+				to:   "123",
+			},
+			"a",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			contains, err := tt.daterange.contains(tt.timestamp)
+			if err == nil {
+				t.Errorf("Expected error, got %t", contains)
+			}
+		})
+	}
+}
+
+func TestValidDateRangeContains(t *testing.T) {
+	tests := []dateRangeTestData{
+		{
+			"'timestamp' in range returns true",
+			DateRange{
+				from: "100",
+				to:   "123",
+			},
+			"110",
+			true,
+		},
+		{
+			"'timestamp' same as 'to' returns true",
+			DateRange{
+				from: "100",
+				to:   "123",
+			},
+			"100",
+			true,
+		},
+		{
+			"'timestamp' same as 'from' returns true",
+			DateRange{
+				from: "100",
+				to:   "123",
+			},
+			"123",
+			true,
+		},
+		{
+			"'timestamp' below range returns false",
+			DateRange{
+				from: "100",
+				to:   "123",
+			},
+			"99",
+			false,
+		},
+		{
+			"'timestamp' above range returns false",
+			DateRange{
+				from: "100",
+				to:   "123",
+			},
+			"124",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			contains, err := tt.daterange.contains(tt.timestamp)
+			if err != nil {
+				t.Errorf("Expected error, got %t", contains)
+			}
+			if contains != tt.expect {
+				t.Errorf("Expected %t, got %t", tt.expect, contains)
+			}
+		})
+	}
+}

--- a/pkg/server/warcserver/daterange_test.go
+++ b/pkg/server/warcserver/daterange_test.go
@@ -1,6 +1,7 @@
 package warcserver
 
 import (
+	"math"
 	"testing"
 )
 
@@ -11,92 +12,51 @@ type dateRangeTestData struct {
 	expect    bool
 }
 
-func TestInValidDateRangeContains(t *testing.T) {
-	tests := []dateRangeTestData{
-		{
-			"invalid 'to' value fails",
-			DateRange{
-				from: "123",
-				to:   "a",
-			},
-			"100",
-			false,
-		},
-		{
-			"invalid 'from' value fails",
-			DateRange{
-				from: "a",
-				to:   "123",
-			},
-			"100",
-			false,
-		},
-		{
-			"invalid 'timestamp' value fails",
-			DateRange{
-				from: "100",
-				to:   "123",
-			},
-			"a",
-			false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			contains, err := tt.daterange.contains(tt.timestamp)
-			if err == nil {
-				t.Errorf("Expected error, got %t", contains)
-			}
-		})
-	}
-}
-
 func TestValidDateRangeContains(t *testing.T) {
 	tests := []dateRangeTestData{
 		{
 			"'timestamp' in range returns true",
 			DateRange{
-				from: "100",
-				to:   "123",
+				from: 0,
+				to:   60,
 			},
-			"110",
-			true,
-		},
-		{
-			"'timestamp' same as 'to' returns true",
-			DateRange{
-				from: "100",
-				to:   "123",
-			},
-			"100",
+			"19700101000010",
 			true,
 		},
 		{
 			"'timestamp' same as 'from' returns true",
 			DateRange{
-				from: "100",
-				to:   "123",
+				from: 0,
+				to:   60,
 			},
-			"123",
+			"19700101000000",
+			true,
+		},
+		{
+			"'timestamp' same as 'to' returns true",
+			DateRange{
+				from: 0,
+				to:   60,
+			},
+			"19700101000100",
 			true,
 		},
 		{
 			"'timestamp' below range returns false",
 			DateRange{
-				from: "100",
-				to:   "123",
+				from: 59,
+				to:   60,
 			},
-			"99",
+			"19700101000000",
 			false,
 		},
 		{
 			"'timestamp' above range returns false",
 			DateRange{
-				from: "100",
-				to:   "123",
+				from: 0,
+				to:   1,
 			},
-			"124",
+			"19700101000200",
 			false,
 		},
 	}
@@ -105,10 +65,105 @@ func TestValidDateRangeContains(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			contains, err := tt.daterange.contains(tt.timestamp)
 			if err != nil {
-				t.Errorf("Expected error, got %t", contains)
+				t.Errorf("Unexpected error: %s", err)
 			}
 			if contains != tt.expect {
 				t.Errorf("Expected %t, got %t", tt.expect, contains)
+			}
+		})
+	}
+}
+
+func TestInvalidContainData(t *testing.T) {
+	test := dateRangeTestData{
+		"invalid 'to' value fails",
+		DateRange{
+			from: 0,
+			to:   60,
+		},
+		"invalid",
+		false,
+	}
+
+	t.Run(test.name, func(t *testing.T) {
+		contains, err := test.daterange.contains(test.timestamp)
+		if err == nil {
+			t.Errorf("Expected error, got %v", err)
+		}
+
+		if contains == true {
+			t.Error("Expected result to be false in event of error")
+		}
+	})
+}
+
+func TestInFromAndToParsing(t *testing.T) {
+	tests := []struct {
+		name         string
+		fromAndTo    string
+		expectedFrom int64
+		expectedTo   int64
+		expectError  bool
+	}{
+		{
+			"valid full date string succeeds",
+			"19700101000000",
+			0,
+			0,
+			false,
+		},
+		{
+			"valid partial date string succeeds",
+			"197001010000",
+			0,
+			59,
+			false,
+		},
+		{
+			"empty date string succeeds",
+			"",
+			math.MinInt64,
+			math.MaxInt64,
+			false,
+		},
+		{
+			"odd number date string fails",
+			"19975",
+			0,
+			0,
+			true,
+		},
+		{
+			"more than 14 number date string fails",
+			"200801122359590",
+			0,
+			0,
+			true,
+		},
+		{
+			"invalid char date string fails",
+			"199A",
+			0,
+			0,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			from, err := From(tt.fromAndTo)
+			if err != nil && !tt.expectError {
+				t.Errorf("Unexpected 'from' error: %s", err)
+			}
+			if from != tt.expectedFrom {
+				t.Errorf("Expected %d, got %d", tt.expectedFrom, from)
+			}
+			to, err := To(tt.fromAndTo)
+			if err != nil && !tt.expectError {
+				t.Errorf("Unexpected 'to' error: %s", err)
+			}
+			if to != tt.expectedTo {
+				t.Errorf("Expected %d, got %d", tt.expectedTo, to)
 			}
 		})
 	}

--- a/pkg/server/warcserver/daterange_test.go
+++ b/pkg/server/warcserver/daterange_test.go
@@ -135,6 +135,20 @@ func TestFromAndToParsing(t *testing.T) {
 			false,
 		},
 		{
+			"normal year date string succeeds",
+			"197002",
+			time.Date(1970, 2, 1, 0, 0, 0, 0, time.UTC).Unix(),
+			time.Date(1970, 2, 28, 23, 59, 59, 0, time.UTC).Unix(),
+			false,
+		},
+		{
+			"leap year date string succeeds",
+			"200002",
+			time.Date(2000, 2, 1, 0, 0, 0, 0, time.UTC).Unix(),
+			time.Date(2000, 2, 29, 23, 59, 59, 0, time.UTC).Unix(),
+			false,
+		},
+		{
 			"empty date string succeeds",
 			"",
 			time.Time{}.Unix(),

--- a/pkg/server/warcserver/routes.go
+++ b/pkg/server/warcserver/routes.go
@@ -35,10 +35,10 @@ func RegisterRoutes(r *mux.Router, db *index.DB, loader *loader.Loader, children
 		indexHandler = handlers.AggregatedHandler(children, timeout)
 		resourceHandler = handlers.FirstHandler(children, timeout)
 	} else {
-		indexHandler = &IndexHandler{DbCdxServer{db},}
+		indexHandler = &IndexHandler{DbCdxServer{db}}
 		resourceHandler = &ResourceHandler{
 			DbCdxServer: DbCdxServer{db},
-			loader: loader,
+			loader:      loader,
 		}
 	}
 


### PR DESCRIPTION
# Changes:
* Parse string values to int before comparing to reduce potential for errors
* Convert date according to pywb [specification](https://pywb.readthedocs.io/en/latest/manual/cdxserver_api.html#from-to) of from and to
* Unit tests for the DateRange struct