### PR TITLE
#60: implement a serial semi unsorted search

### DIFF
--- a/internal/server/warcserver/daterange.go
+++ b/internal/server/warcserver/daterange.go
@@ -49,7 +49,7 @@ func NewDateRange(fromstr string, tostr string) (*DateRange, error) {
 
 // contains returns true if the timestamp ts contained by the bounds defined by the DateRange d.
 // input 'ts' is 'trusted' and does not have the same parsing complexity as a From or To string
-func (d *DateRange) contains(ts string) (bool, error) {
+func (d *DateRange) containsStr(ts string) (bool, error) {
 	if d == nil {
 		return true, nil
 	}
@@ -58,6 +58,15 @@ func (d *DateRange) contains(ts string) (bool, error) {
 		return false, fmt.Errorf("failed to parse ts: %w", err)
 	}
 	unixTs := timestamp.Unix()
+	return unixTs >= d.from && unixTs <= d.to, nil
+}
+
+// contains returns true if the timestamp ts contained by the bounds defined by the DateRange d.
+func (d *DateRange) containsTime(ts time.Time) (bool, error) {
+	if d == nil {
+		return true, nil
+	}
+	unixTs := ts.Unix()
 	return unixTs >= d.from && unixTs <= d.to, nil
 }
 

--- a/internal/server/warcserver/daterange_test.go
+++ b/internal/server/warcserver/daterange_test.go
@@ -70,7 +70,7 @@ func TestValidDateRangeContains(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			contains, err := tt.daterange.contains(tt.datestr)
+			contains, err := tt.daterange.containsStr(tt.datestr)
 			if err != nil {
 				t.Errorf("Testing %s; Unexpected error: %s", tt.name, err)
 			}
@@ -93,7 +93,7 @@ func TestInvalidContainData(t *testing.T) {
 	}
 
 	t.Run(test.name, func(t *testing.T) {
-		contains, err := test.daterange.contains(test.datestr)
+		contains, err := test.daterange.containsStr(test.datestr)
 		if err == nil {
 			t.Errorf("Expected error, got %v", err)
 		}


### PR DESCRIPTION
also removed parallelunsorted search. It remains in git history if we want to fix it later

# NOTE
I have not tested this with a dataset where there are both http and https results, so it would be good if reviewer could validate that this actually sort across http and https results or supply warc file(s) where this occurs 