### PR TITLE
Resolve revisit by WARC-Refers-To-Target-URI and Warc-Refers-To-Date

### DIFF
--- a/index/record.go
+++ b/index/record.go
@@ -153,15 +153,17 @@ func (r Record) Marshal() ([]byte, error) {
 	value, err := proto.Marshal(r)
 	if err != nil && strings.HasSuffix(err.Error(), "contains invalid UTF-8") {
 		// sanitize MIME type
-		r.Mct = HandleInvalidUtf8String(r.GetMct())
+		r.Mct = handleInvalidUtf8String(r.GetMct())
+		r.Uri = handleInvalidUtf8String(r.GetUri())
+		r.Ssu = handleInvalidUtf8String(r.GetSsu())
 		// and retry
 		value, err = proto.Marshal(r)
 	}
 	return value, err
 }
 
-// HandleInvalidUtf8String removes invalid utf-8 runes from a string.
-func HandleInvalidUtf8String(s string) string {
+// handleInvalidUtf8String removes invalid utf-8 runes from a string.
+func handleInvalidUtf8String(s string) string {
 	if !utf8.ValidString(s) {
 		v := make([]rune, 0, len(s))
 		for i, r := range s {

--- a/index/record.go
+++ b/index/record.go
@@ -153,15 +153,15 @@ func (r Record) Marshal() ([]byte, error) {
 	value, err := proto.Marshal(r)
 	if err != nil && strings.HasSuffix(err.Error(), "contains invalid UTF-8") {
 		// sanitize MIME type
-		r.Mct = handleInvalidUtf8String(r.GetMct())
+		r.Mct = HandleInvalidUtf8String(r.GetMct())
 		// and retry
 		value, err = proto.Marshal(r)
 	}
 	return value, err
 }
 
-// handleInvalidUtf8String removes invalid utf-8 runes from a string.
-func handleInvalidUtf8String(s string) string {
+// HandleInvalidUtf8String removes invalid utf-8 runes from a string.
+func HandleInvalidUtf8String(s string) string {
 	if !utf8.ValidString(s) {
 		v := make([]rune, 0, len(s))
 		for i, r := range s {

--- a/internal/badgeridx/db.go
+++ b/internal/badgeridx/db.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -273,12 +272,6 @@ func marshalCdxKey(r index.Record) ([]byte, []byte, error) {
 	ts := timestamp.TimeTo14(r.GetSts().AsTime())
 	key := []byte(r.GetSsu() + " " + ts + " " + r.GetSrt())
 	value, err := r.Marshal()
-	if err != nil && strings.HasSuffix(err.Error(), "contains invalid UTF-8") {
-		r.Uri = index.HandleInvalidUtf8String(r.GetUri())
-		r.Ssu = index.HandleInvalidUtf8String(r.GetSsu())
-		// and retry
-		value, err = r.Marshal()
-	}
 	return key, value, err
 }
 

--- a/internal/tikvidx/db.go
+++ b/internal/tikvidx/db.go
@@ -273,12 +273,6 @@ func cdxKV(r index.Record) (KV, error) {
 	ts := timestamp.TimeTo14(r.GetSts().AsTime())
 	k := []byte(cdxPrefix + r.GetSsu() + " " + ts + " " + r.GetSrt())
 	v, err := r.Marshal()
-	if err != nil && strings.HasSuffix(err.Error(), "contains invalid UTF-8") {
-		r.Uri = index.HandleInvalidUtf8String(r.GetUri())
-		r.Ssu = index.HandleInvalidUtf8String(r.GetSsu())
-		// and retry
-		v, err = r.Marshal()
-	}
 	if err != nil {
 		return KV{}, err
 	}

--- a/internal/tikvidx/db.go
+++ b/internal/tikvidx/db.go
@@ -273,6 +273,12 @@ func cdxKV(r index.Record) (KV, error) {
 	ts := timestamp.TimeTo14(r.GetSts().AsTime())
 	k := []byte(cdxPrefix + r.GetSsu() + " " + ts + " " + r.GetSrt())
 	v, err := r.Marshal()
+	if err != nil && strings.HasSuffix(err.Error(), "contains invalid UTF-8") {
+		r.Uri = index.HandleInvalidUtf8String(r.GetUri())
+		r.Ssu = index.HandleInvalidUtf8String(r.GetSsu())
+		// and retry
+		v, err = r.Marshal()
+	}
 	if err != nil {
 		return KV{}, err
 	}

--- a/loader/filestorageloader.go
+++ b/loader/filestorageloader.go
@@ -39,7 +39,7 @@ func (f FileStorageLoader) Load(ctx context.Context, storageRef string) (record 
 	if err != nil {
 		return nil, err
 	}
-	log.Debug().Msgf("Loading record from file: %s, offset: %v", filePath, offset)
+	log.Debug().Str("storageRef", storageRef).Msgf("Loading record from file: %s, offset: %v", filePath, offset)
 
 	wf, err := gowarc.NewWarcFileReader(filePath, offset,
 		gowarc.WithSyntaxErrorPolicy(gowarc.ErrIgnore),

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -79,7 +79,11 @@ func (l *Loader) LoadByStorageRef(ctx context.Context, storageRef string) (gowar
 	//nolint:exhaustive
 	switch record.Type() {
 	case gowarc.Revisit:
-		log.Debug().Msgf("Resolving revisit  %v -> %v", record.RecordId(), record.WarcHeader().Get(gowarc.WarcRefersTo))
+		log.Debug().Str("storageRef", storageRef).
+			Str("warcRefersTo", record.WarcHeader().Get(gowarc.WarcRefersTo)).
+			Str("warcRefersToTargetURI", record.WarcHeader().Get(gowarc.WarcRefersToTargetURI)).
+			Str("warcRefersToDate", record.WarcHeader().Get(gowarc.WarcRefersToDate)).
+			Msg("Loader found a revisit record")
 		warcRefersTo := record.WarcHeader().GetId(gowarc.WarcRefersTo)
 		if warcRefersTo == "" {
 			warcRefersToTargetURI := record.WarcHeader().Get(gowarc.WarcRefersToTargetURI)

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/nlnwa/gowarc"
 	"github.com/rs/zerolog/log"
 )
@@ -83,10 +82,18 @@ func (l *Loader) LoadByStorageRef(ctx context.Context, storageRef string) (gowar
 		log.Debug().Msgf("Resolving revisit  %v -> %v", record.RecordId(), record.WarcHeader().Get(gowarc.WarcRefersTo))
 		warcRefersTo := record.WarcHeader().GetId(gowarc.WarcRefersTo)
 		if warcRefersTo == "" {
+			warcRefersToTargetURI := record.WarcHeader().Get(gowarc.WarcRefersToTargetURI)
+			warcRefersToDate := record.WarcHeader().Get(gowarc.WarcRefersToDate)
+			if warcRefersToTargetURI == "" {
+				return nil, fmt.Errorf("failed to resolve revisit record: neither WARC-Refers-To nor Warc-Refers-To-Target-URI")
+			}
+			if warcRefersToDate == "" {
+				warcRefersToDate = record.WarcHeader().Get(gowarc.WarcDate)
+			}
 			return nil, ErrResolveRevisit{
 				Profile:   record.WarcHeader().Get(gowarc.WarcProfile),
-				TargetURI: record.WarcHeader().Get(gowarc.WarcRefersToTargetURI),
-				Date:      record.WarcHeader().Get(gowarc.WarcRefersToDate),
+				TargetURI: warcRefersToTargetURI,
+				Date:      warcRefersToDate,
 			}
 		}
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/nlnwa/gowarc"
 	"github.com/rs/zerolog/log"
+	"strings"
 )
 
 type StorageRefResolver interface {
@@ -81,7 +82,8 @@ func (l *Loader) LoadByStorageRef(ctx context.Context, storageRef string) (gowar
 	case gowarc.Revisit:
 		log.Debug().Msgf("Resolving revisit  %v -> %v", record.RecordId(), record.WarcHeader().Get(gowarc.WarcRefersTo))
 		warcRefersTo := record.WarcHeader().GetId(gowarc.WarcRefersTo)
-		if warcRefersTo == "" {
+		// hack: workaround erroneous WARC-Refers-To urn
+		if warcRefersTo == "" || strings.HasSuffix(warcRefersTo[:len(warcRefersTo)-1], "\u0000") {
 			warcRefersToTargetURI := record.WarcHeader().Get(gowarc.WarcRefersToTargetURI)
 			warcRefersToDate := record.WarcHeader().Get(gowarc.WarcRefersToDate)
 			if warcRefersToTargetURI == "" {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"github.com/nlnwa/gowarc"
 	"github.com/rs/zerolog/log"
-	"strings"
 )
 
 type StorageRefResolver interface {
@@ -82,8 +81,7 @@ func (l *Loader) LoadByStorageRef(ctx context.Context, storageRef string) (gowar
 	case gowarc.Revisit:
 		log.Debug().Msgf("Resolving revisit  %v -> %v", record.RecordId(), record.WarcHeader().Get(gowarc.WarcRefersTo))
 		warcRefersTo := record.WarcHeader().GetId(gowarc.WarcRefersTo)
-		// hack: workaround erroneous WARC-Refers-To urn
-		if warcRefersTo == "" || strings.HasSuffix(warcRefersTo[:len(warcRefersTo)-1], "\u0000") {
+		if warcRefersTo == "" {
 			warcRefersToTargetURI := record.WarcHeader().Get(gowarc.WarcRefersToTargetURI)
 			warcRefersToDate := record.WarcHeader().Get(gowarc.WarcRefersToDate)
 			if warcRefersToTargetURI == "" {

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -51,7 +51,7 @@ type ErrResolveRevisit struct {
 }
 
 func (e ErrResolveRevisit) Error() string {
-	return fmt.Sprintf("Resolving via Warc-Refers-To-Date and Warc-Refers-To-Target-URI is not implemented: %s", e.String())
+	return fmt.Sprintf("Resolving via Warc-Refers-To-Date and Warc-Refers-To-Target-URI failed: %s", e.String())
 }
 
 func (e ErrResolveRevisit) String() string {

--- a/server/warcserver/handler.go
+++ b/server/warcserver/handler.go
@@ -98,6 +98,7 @@ func (h Handler) resolveRevisit(ctx context.Context, targetURI string, closest s
 			continue
 		}
 		ref = res.GetRef()
+		break
 	}
 
 	return ref, nil


### PR DESCRIPTION
- Fixes redirects to locations with query parameters
- Handle invalid UTF-8 characters in record causing marshalling to fail