### PR TITLE
Fix redirect loop

### DIFF
--- a/server/api/api.go
+++ b/server/api/api.go
@@ -139,6 +139,10 @@ func (c *SearchRequest) SetLimit(limit int) {
 	c.limit = limit
 }
 
+func (c *SearchRequest) SetMatchType(matchType index.MatchType) {
+	c.matchType = matchType
+}
+
 var schemeRegExp = regexp.MustCompile(`^[a-z][a-z0-9+\-.]+(:.*)`)
 
 func Parse(values url.Values) (req *SearchRequest, err error) {
@@ -265,6 +269,6 @@ func ClosestRequest(closest string, url *whatwgUrl.Url) *SearchRequest {
 		limit:     10,
 		sort:      index.SortClosest,
 		closest:   closest,
-		matchType: index.MatchTypeExact,
+		matchType: index.MatchTypeVerbatim,
 	}
 }

--- a/server/warcserver/handler.go
+++ b/server/warcserver/handler.go
@@ -45,6 +45,11 @@ func (h Handler) index(w http.ResponseWriter, r *http.Request) {
 		coreAPI.SetLimit(h.Config.PrefixSearchLimit)
 	}
 
+	if coreAPI.Sort() == index.SortClosest &&
+		coreAPI.MatchType() == index.MatchTypeExact {
+		coreAPI.SetMatchType(index.MatchTypeVerbatim)
+	}
+
 	start := time.Now()
 	count := 0
 	defer func() {


### PR DESCRIPTION
This commit fixes a redirect loop that occurs in certain cases when using the warcserver API from pywb.

To avoid the redirect loop, index searches with sort=closest and the searches performed when fetching resources now use the verbatim matchType.